### PR TITLE
Morphine Fix

### DIFF
--- a/gamemodes/nzombies/gamemode/player_class/sv_healthregen.lua
+++ b/gamemodes/nzombies/gamemode/player_class/sv_healthregen.lua
@@ -1,6 +1,6 @@
 local HealthRegen = {
-	Amount = 1,
-	Delay = 2,
+	Amount = 10,
+	Delay = 3,
 	Rate = 0.05
 }
 

--- a/gamemodes/nzombies/gamemode/revive_system/sh_revival.lua
+++ b/gamemodes/nzombies/gamemode/revive_system/sh_revival.lua
@@ -48,7 +48,7 @@ function nzRevive.HandleRevive(ply, ent)
 					ply.Reviving = nil
 				end
 			end
-		elseif IsValid(ply.Reviving) and ply.Reviving != dply -- Holding E on another player or no player
+		elseif ply.LastReviveTime ~= nil and IsValid(ply.Reviving) and ply.Reviving != dply -- Holding E on another player or no player
 		and ct > ply.LastReviveTime + revivefailtime then -- and for longer than fail time window
 			local id = ply.Reviving:EntIndex()
 			if nzRevive.Players[id] then

--- a/gamemodes/nzombies/gamemode/round/sv_round.lua
+++ b/gamemodes/nzombies/gamemode/round/sv_round.lua
@@ -360,6 +360,9 @@ function nzRound:ResetGame()
 	for _, ply in pairs(player.GetAll()) do
 		ply:SetPoints(0) --Reset all player points
 		ply:RemovePerks() --Remove all players perks
+		ply:SetTotalRevives(0) --Reset all player total revive
+		ply:SetTotalDowns(0) --Reset all player total down
+		ply:SetTotalKills(0) --Reset all player total kill
 	end
 
 	--Clean up powerups


### PR DESCRIPTION
#414 Fix **Hopefully**

nzombies/gamemodes/nzombies/gamemode/special_weapons/sh_specialweapons.lua

1.
2. local function RegisterDefaultSpecialWeps()
3. nzSpecialWeapons:AddKnife( "nz_quickknife_crowbar", false, 0.65 )
4. nzSpecialWeapons:AddKnife( "nz_bowie_knife", true, 0.65, 2.5 )
5. nzSpecialWeapons:AddKnife( "nz_one_inch_punch", true, 0.75, 1.5 )
6.
7. nzSpecialWeapons:AddGrenade( "nz_grenade", 4, false, 0.85, false, 0.4 ) -- ALWAYS pass false instead of nil or it'll assume default value
8. nzSpecialWeapons:AddSpecialGrenade( "nz_monkey_bomb", 3, false, 3, false, 0.4 )
9.
10. nzSpecialWeapons:AddDisplay( "nz_revive_morphine", false, function(wep)
11.	return !(IsValid(wep.Owner:GetPlayerReviving()) and wep.Owner:KeyDown(IN_USE))
12. end)
13.
14. nzSpecialWeapons:AddDisplay( "nz_perk_bottle", false, function(wep)
15.	return SERVER and CurTime() > wep.nzDeployTime + 3.1
16. end)
17.
18. nzSpecialWeapons:AddDisplay( "nz_packapunch_arms", false, function(wep)
19.	return SERVER and CurTime() > wep.nzDeployTime + 2.5
20. end)
21. end
22.
23. hook.Add("InitPostEntity", "nzRegisterSpecialWeps", RegisterDefaultSpecialWeps)
24. --hook.Add("OnReloaded", "nzRegisterSpecialWeps", RegisterDefaultSpecialWeps)